### PR TITLE
Read YOUR_LOG_TOKEN by os.environ

### DIFF
--- a/le_config.py
+++ b/le_config.py
@@ -1,15 +1,17 @@
+import os
+
 # Logentries tokens
 # This token is used to associate AWS CloudWatch logs to a log in your Logentries account.
-log_token = "{YOUR_LOG_TOKEN}"
+log_token = os.environ['YOUR_LOG_TOKEN']
 
 # You can supply an optional token to log activity to a log on Logentries and any errors from this script.
 # This is optional, it is recommended you use one log file/token for all your Lambda scripts. If you do not
 # wish to use this, just leave the value blank.
-debug_token = "{YOUR_DEBUG_TOKEN}"
+debug_token = os.environ.get('YOUR_DEBUG_TOKEN', '')
 
 # Log to generic activity from this script to our support logging system for Lambda scripts
 # this is optional, but helps us improve our service nad can be hand for us helping you debug any issues
 # just remove this token if you wish (leave variable in place)
-lambda_token = "0ae0162e-855a-4b54-9ae3-bd103006bfc0"
+lambda_token = os.environ.get('LE_SUPPORT_TOKEN', '')
 
-username = "{YOUR_USERNAME}"
+username = os.environ.get('YOUR_USERNAME', '')

--- a/le_config.py
+++ b/le_config.py
@@ -12,6 +12,6 @@ debug_token = os.environ.get('YOUR_DEBUG_TOKEN', '')
 # Log to generic activity from this script to our support logging system for Lambda scripts
 # this is optional, but helps us improve our service nad can be hand for us helping you debug any issues
 # just remove this token if you wish (leave variable in place)
-lambda_token = os.environ.get('LE_SUPPORT_TOKEN', '')
+lambda_token = os.environ.get('LE_SUPPORT_TOKEN', '0ae0162e-855a-4b54-9ae3-bd103006bfc0')
 
 username = os.environ.get('YOUR_USERNAME', '')


### PR DESCRIPTION
AWS Lambda now supports environment variables. Is this an acceptable convention to read from os.environ to obtain ```YOUR_LOG_TOKEN``` ?